### PR TITLE
fix: extraction of module name from go.mod

### DIFF
--- a/.github/workflows/module-info.yml
+++ b/.github/workflows/module-info.yml
@@ -41,7 +41,7 @@ jobs:
         gover=$(cat go.mod | grep ^go); gover=${gover##* }
 
         # get module name from go.mod
-        module=$(cat go.mod | grep module); module=${module## }
+        module=$(cat go.mod | grep module -m 1); module=${module## }
 
         # remove any /vN version suffix ...
         while [[ $module == *[0-9] ]]; do module=${module%?}; done


### PR DESCRIPTION
the module name is extracted by grep'ing for "module" in go.mod.  If the word module is used in any retraction comments or module names in any require directives, multiple matches are returned and the pattern matching for extracting the module name returns incorrect results.

since the module directive should always be the first entry in a go.mod, limiting grep to return only the first match ensures that the correct result is returned 