### PR TITLE
support private repos

### DIFF
--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -1,0 +1,76 @@
+name: BuildService
+
+on:
+  workflow_call:
+    outputs:
+      moduleName:
+        value: ${{ jobs.qa.outputs.moduleName }}
+      ingressPath:
+        value: ${{ jobs.qa.outputs.ingressPath }}
+      serviceName:
+        value: ${{ jobs.qa.outputs.serviceName }}
+      gitVersion:
+        value: ${{ jobs.qa.outputs.gitVersion }}
+      goVersion:
+        value: ${{ jobs.qa.outputs.goVersion }}
+
+jobs:
+  qa:
+    uses: ./.github/workflows/module-qa.yml
+    secrets: inherit
+  
+  build:
+    name: 'build ${{ needs.qa.outputs.gitVersion }}'
+    runs-on: ubuntu-latest
+    needs:
+    - qa
+    outputs:
+      gitVersion: ${{ needs.qa.outputs.gitVersion }}
+      serviceName: ${{ needs.qa.outputs.serviceName }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+
+    - name: 'setup: docker buildx'
+      uses: docker/setup-buildx-action@v2
+
+    - name: 'docker: login'
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: 'docker: extract metadata'
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ghcr.io/${{ github.repository_owner }}/${{ needs.qa.outputs.serviceName }}
+
+    - name: 'docker: build'
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: .cicd/dockerfile
+        provenance: false # not currently supported by ghcr.io
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/${{ needs.qa.outputs.serviceName }}:${{ needs.qa.outputs.gitVersion }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+  cleanup:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/master' }}
+    needs:
+    - build
+    steps:
+    - name: 'ghcr: prune'
+      uses: vlaurin/action-ghcr-prune@v0.5.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        organization: ${{ github.repository_owner }}
+        container: ${{ needs.build.outputs.serviceName }}
+        prune-untagged: true
+        keep-tags-regexes:
+          ^[0-9]+.[0-9]+.[0-9]+$
+        prune-tags-regexes:
+          ^[0-9]+.[0-9]+.[0-9]+-.*$

--- a/.github/workflows/module-info.yml
+++ b/.github/workflows/module-info.yml
@@ -2,11 +2,18 @@ name: ModuleInfo
 
 on:
   workflow_call:
+    inputs:
+      path:
+        description: 'path to go.mod (if not in root))'
+        type: string
+        required: false
     outputs:
-      moduleKey:
-        value: ${{ jobs.module-info.outputs.moduleKey }}
       moduleName:
         value: ${{ jobs.module-info.outputs.moduleName }}
+      serviceName:
+        value: ${{ jobs.module-info.outputs.serviceName }}
+      ingressPath:
+        value: ${{ jobs.module-info.outputs.ingressPath }}
       gitVersion:
         value: ${{ jobs.module-info.outputs.gitVersion }}
       goVersion:
@@ -15,8 +22,9 @@ on:
 jobs:
   module-info:
     outputs:
-      moduleKey: ${{ steps.info.outputs.moduleKey }}
       moduleName: ${{ steps.info.outputs.moduleName }}
+      serviceName: ${{ steps.info.outputs.serviceName }}
+      ingressPath: ${{ steps.info.outputs.ingressPath }}
       gitVersion: ${{ steps.info.outputs.gitVersion }}
       goVersion: ${{ steps.info.outputs.goVersion }}
     runs-on: ubuntu-latest
@@ -34,26 +42,44 @@ jobs:
       id:   gitversion # id to later be referenced
       uses: gittools/actions/gitversion/execute@v0
 
-    - name: parse go.mod
+    - name: 'go.mod: parse'
       id: info
       run: |
-        # get go version from go.mod
-        gover=$(cat go.mod | grep ^go); gover=${gover##* }
+        modfile="go.mod"
+        [[ ! -z "${{ inputs.path }}" ]] && modfile="${{ inputs.path }}/go.mod"
+
+        mod=$(cat $modfile)
 
         # get module name from go.mod
-        module=$(cat go.mod | grep module -m 1); module=${module## }
+        module=$(echo "$mod" | grep -E "^module " -m 1); module=${module##* }; module=${module%% *}
+        
+        # remove any /vNN version suffix ...
+        if [[ ! -z $(echo "$module" | grep -E "^.*/v[0-9]+$") ]]; then
+          while [[ ! -z $(echo "$module" | grep -E "^.*/v[0-9]+$") ]]; do module=${module%?}; done
+          module=${module%??};
+        fi
 
-        # remove any /vN version suffix ...
-        while [[ $module == *[0-9] ]]; do module=${module%?}; done
-        if [[ $module == */v ]]; then module=${module%??}; fi
+        # get go version from go.mod
+        gover=$(echo "$mod" | grep -E "^go "); gover=${gover##* }; gover=${gover%% *}
 
-        # .. and remove the github.com/ prefix,
-        # replacing '/' with ':' and converting to lowercase for the key
-        name=$(echo ${module#*github.com/})
-        key=$(echo $name | tr '/' ':' | tr '[:upper:]' '[:lower:]')
+        # get service name from go.mod
+        service=$(echo "$mod" | grep -E "^//service:name:" -m 1); service=${service##*:};
+
+        # if the service name is not explicitly set but a //service comment is
+        # present then use the module name as the service name (without host.tld/ prefix)
+        if [[ -z $service && ! -z $(echo "$mod" | grep -E "^//service[\s]*$") ]]; then
+          if [[ ! -z $(echo "$module" | grep "/") ]]; then service=${module##*/}; fi
+          if [[ -z $service ]]; then service=$module; fi
+        fi
+        service=${service%% *}
+        
+        # get ingress path from go.mod
+        ingress=$(echo "$mod" | grep -E "^//ingress:path:" -m 1); ingress=${ingress##*:};
+        
         gitver=$(echo ${{ steps.gitversion.outputs.semVer }} | tr '[:upper:]' '[:lower:]')
 
+        echo "serviceName=$service" >> $GITHUB_OUTPUT
+        echo "ingressPath=$ingress" >> $GITHUB_OUTPUT
         echo "moduleName=$name" >> $GITHUB_OUTPUT
-        echo "moduleKey=$key" >> $GITHUB_OUTPUT
         echo "gitVersion=$gitver" >> $GITHUB_OUTPUT
         echo "goVersion=$gover" >> $GITHUB_OUTPUT

--- a/.github/workflows/module-qa.yml
+++ b/.github/workflows/module-qa.yml
@@ -2,67 +2,89 @@ name: ModuleQuality
 
 on:
   workflow_call:
-    inputs:
-      go-version:
-        description: 'Go Version'
-        required: false
-        default: '1.20.4'
-        type: string
+    outputs:
+      moduleName:
+        value: ${{ jobs.module-info.outputs.moduleName }}
+      serviceName:
+        value: ${{ jobs.module-info.outputs.serviceName }}
+      ingressPath:
+        value: ${{ jobs.module-info.outputs.ingressPath }}
+      gitVersion:
+        value: ${{ jobs.module-info.outputs.gitVersion }}
+      goVersion:
+        value: ${{ jobs.module-info.outputs.goVersion }}
 
 jobs:
   module-info:
     uses: ./.github/workflows/module-info.yml
 
-  test:
+  repo-visibility:
+    runs-on: ubuntu-latest
+    outputs:
+      isPublic: ${{ steps.visibility.outputs.is_public }}
+    steps:
+      - uses: credfeto/action-repo-visibility@v1.2.0
+        id: visibility
+
+  qa:
+    if: ${{ (github.ref != 'refs/heads/master' ) || (needs.repo-visibility.outputs.isPublic =='true') }}
     needs:
-    - module-info
+      - module-info
+      - repo-visibility
+    outputs:
+      gitVersion: ${{ needs.module-info.outputs.gitVersion }}
+      isPublic: ${{ needs.repo-visibility.outputs.isPublic }}
+      moduleName: ${{ needs.module-info.outputs.moduleName }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      
+      - name: 'setup: go ${{ needs.module-info.outputs.goVersion }}'
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ needs.module-info.outputs.goVersion }}
+        
+      - name: 'go: lint'
+        if: ${{ github.ref != 'refs/heads/master' }}
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+
+      - name: 'go: test'
+        run: go mod download && go test -v -coverprofile=profile.cov ./...
+
+      - name: 'upload: profile.cov'
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverprofile
+          path: profile.cov
+
+  coveralls:
+    if: ${{ (github.ref != 'refs/heads/master') && (needs.qa.outputs.isPublic =='true') }}
+    needs:
+      - qa
     runs-on: ubuntu-latest
     steps:
     - name: checkout
       uses: actions/checkout@v3
-      
-    - name: setup go ${{ needs.module-info.outputs.goVersion }}
-      uses: actions/setup-go@v3
       with:
-        go-version: ${{ needs.module-info.outputs.goVersion }}
+        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-    - name: go test
-      run: go test -v -coverprofile=profile.cov ./...
-
-    - name: upload profile.cov
-      uses: actions/upload-artifact@v3
+    - name: download profile.cov
+      uses: actions/download-artifact@v3
       with:
         name: coverprofile
-        path: profile.cov
 
     - name: send coverage to coveralls
       uses: shogo82148/actions-goveralls@v1
       with:
         path-to-profile: profile.cov
 
-
-  lint:
-    needs:
-    - module-info
-    runs-on: ubuntu-latest
-    steps:
-    - name: checkout
-      uses: actions/checkout@v3
-
-    - name: setup go ${{ needs.module-info.outputs.goVersion }}
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ needs.module-info.outputs.goVersion }}
-
-    - name: lint
-      uses: golangci/golangci-lint-action@v3
-      with:
-        version: latest
-
   sonarcloud:
+    if: ${{ needs.qa.outputs.isPublic =='true' }}
     needs:
-      - module-info
-      - test
+      - qa
     runs-on: ubuntu-latest
     steps:
     - name: checkout
@@ -77,11 +99,18 @@ jobs:
 
     - name: create sonar-project.properties
       run: |
+        # remove the github.com/ prefix from the module name, replace
+        # '/' with ':' and convert to lowercase to derive a project
+        # key for SonarCloud
+        moduleName="${{ needs.qa.outputs.moduleName }}"
+        key=$(echo ${moduleName#*github.com/})
+        key=$(echo $key | tr '/' ':' | tr '[:upper:]' '[:lower:]')
+
         cat << EOF >> sonar-project.properties
         sonar.organization=blugnu
-        sonar.projectKey=${{ needs.module-info.outputs.moduleKey }}
-        sonar.projectName=${{ needs.module-info.outputs.moduleName }}
-        sonar.projectVersion=${{ needs.module-info.outputs.gitVersion }}
+        sonar.projectKey=$key
+        sonar.projectName=${{ needs.qa.outputs.moduleName }}
+        sonar.projectVersion=${{ needs.qa.outputs.gitVersion }}
 
         sonar.go.coverage.reportPaths=profile.cov
 
@@ -95,6 +124,7 @@ jobs:
         EOF
 
         cat sonar-project.properties
+
     - name: perform sonarcloud scan
       uses: SonarSource/sonarcloud-github-action@master
       env:


### PR DESCRIPTION
Currently only public repositories are supported by SonarCloud (requires subscription to support private repos) and publishing coverage reports to coveralls only makes sense for public repos.

These changes incorporate a repo visibility test and only perform coveralls and SonarCloud steps for public repos (in the future, private repos may be supported for SonarCloud via a workflow input to override this).

In addition, a module-info step is now provided which extracts metadata from the go.mod, including additional annotation-style comments for decorating a module to identify it as a service and (optionally) having a related ingress path (for kubernetes deployments).

A build-service workflow is now also provided which will may be used to build a service following successful a module-qa process, publishing a container to ghcr.io and removing pre-release containers on master