### PR TITLE
update golangci-lint action to v4

### DIFF
--- a/.github/workflows/module-qa.yml
+++ b/.github/workflows/module-qa.yml
@@ -77,7 +77,7 @@ jobs:
         
       - name: 'go: lint'
         if: ${{ github.ref != 'refs/heads/master' }}
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: latest
 


### PR DESCRIPTION
golangi/golangci-lint-action updated to v4 from v3 to address Node.js v16 warnings in action runner