### PR TITLE
disable go-setup cache

### DIFF
--- a/.github/workflows/module-qa.yml
+++ b/.github/workflows/module-qa.yml
@@ -74,6 +74,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ needs.module-info.outputs.goVersion }}
+          cache: false   # avoid "file exists" errors from tar: https://github.com/actions/setup-go/issues/403
         
       - name: 'go: lint'
         if: ${{ github.ref != 'refs/heads/master' }}


### PR DESCRIPTION
Disabling the cache on the go-setup action to avoid "Cannot open: file exists" errors.

see: https://github.com/actions/setup-go/issues/403