### PR TITLE
fix module release workflow

### DIFF
--- a/.github/workflows/git-log.yml
+++ b/.github/workflows/git-log.yml
@@ -71,7 +71,7 @@ jobs:
             preamble="^[0-9a-fA-F]{7} \(.*\)"
             badRefactorings=$(echo "log" | grep -E "$preamble (refactor!|refactor\(.*\)!): .*$" -c)
             breaking=$(echo "$log" | grep -E " (feat!|feat\(.*\)!|fix!|fix\(.*\)!): .*$" -c)
-            fixes=$(echo "$log" | grep -E " (fix|\(.*\)): .*$" -c)
+            fixes=$(echo "$log" | grep -E " (fix|fix\(.*\)): .*$" -c)
             features=$(echo "$log" | grep -E " (feat|feat\(.*\)): .*$" -c)
             refactorings=$(echo "$log" | grep -E " (refactor|refactor\(.*\)): .*$" -c)
 

--- a/.github/workflows/module-qa.yml
+++ b/.github/workflows/module-qa.yml
@@ -72,7 +72,8 @@ jobs:
       - name: 'setup: go ${{ needs.module-info.outputs.goVersion }}'
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ needs.module-info.outputs.goVersion }}
+          # go-version: ${{ needs.module-info.outputs.goVersion }}
+          go-version: 1.22 #TEMP: until workflows are updated to download and use test-report binaries
           cache: false   # avoid "file exists" errors from tar: https://github.com/actions/setup-go/issues/403
         
       - name: 'go: lint'

--- a/.github/workflows/module-release.yml
+++ b/.github/workflows/module-release.yml
@@ -8,10 +8,11 @@ jobs:
     secrets: inherit
 
   release:
-    if: ${{ (github.ref == 'refs/heads/master') }}
     needs:
       - module-qa
     uses: ./.github/workflows/release.yml
     with:
       version: ${{ needs.module-qa.outputs.semver }}
+      createRelease: ${{ (github.ref == 'refs/heads/master') }}
       createTag: ${{ needs.module-qa.outputs.isTagged == 'false' }}
+    secrets: inherit

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "MD013": { "line_length": 200 }, // self-enforce to ~100; 200 allows for some tables
+    "MD033": false // allow inline HTML
+}


### PR DESCRIPTION
- corrected parameters when calling `release` from `module-release`
- enabled releases of modules using go version < 1.21 (required by `test-report`)
- fixed issue with versioning of scoped fix commits
- improved documentation