### PR TITLE
correct module-release parameters and fail-fast release if config is empty

### DIFF
--- a/.github/workflows/module-release.yml
+++ b/.github/workflows/module-release.yml
@@ -1,4 +1,4 @@
-name: ModulePipeline
+name: ModuleRelease
 on:
   workflow_call:
    
@@ -14,5 +14,5 @@ jobs:
     with:
       version: ${{ needs.module-qa.outputs.semver }}
       createRelease: ${{ (github.ref == 'refs/heads/master') }}
-      createTag: ${{ needs.module-qa.outputs.isTagged == 'false' }}
+      createTag: ${{ !fromJSON(needs.module-qa.outputs.isTagged) }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,19 +28,22 @@ jobs:
       - name: 'release: check configuration'
         id: config
         run: |
+          # a script to check for the presence of a .goreleaser.yml file
+
           if [[ -f .goreleaser.yml ]]; then
+            if [[ -z "$(cat .goreleaser.yml)" ]]; then
+              echo "::error::.goreleaser.yml is empty"
+              exit 1
+            fi
+
             echo "::group::.goreleaser.yml"
               cat .goreleaser.yml
             echo "::endgroup::"
             exit 0
           fi
 
-          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
-            echo "::error::no .goreleaser.yml"
-            exit 1
-          fi
-          
-          echo "::warning::no .goreleaser.yml"
+          echo "::error::no .goreleaser.yml)"
+          exit 1
 
       # create a tag
       - name: 'release: create tag'


### PR DESCRIPTION
- coerce the `createTag` parameter to a boolean value using `fromJSON()`
- fail the `release` job if `.goreleaser.yml` exists but is empty